### PR TITLE
Base template changes

### DIFF
--- a/project_name/templates/project_name/base.html
+++ b/project_name/templates/project_name/base.html
@@ -40,6 +40,8 @@
 			js                        individual pages
 {% endcomment %}
 
+{% load compress %}
+
 {% block base_css %}
 	<link rel="stylesheet" href="{% static "bootstrap/dist/css/bootstrap.css" %}">
 	{% if COMPRESS_ENABLED %}
@@ -47,14 +49,13 @@
 	{% else %}
 		<link rel="stylesheet" href="{% static "font-awesome/css/font-awesome.css" %}">
 	{% endif %}
-{% endblock %}
-
-{% block main_css %}
 	{% endverbatim %}{% templatetag openblock %} compile less "{{ project_name }}/less/main.less" {% templatetag closeblock %}{% verbatim %}
 {% endblock %}
 
 {% block head_js %}
-	<script src="{% static "modernizr/modernizr.js" %}"></script>
+	{% compress js file %}
+		<script src="{% static "modernizr/modernizr.js" %}"></script>
+	{% endcompress %}
 {% endblock %}
 
 {% block body %}


### PR DESCRIPTION
- Shifted the project's main stylesheet out into the `main_css` block, which allows it to more easily override lib css which tends to be dumped into `css`.
- Cleaned up some mixed indentation in the comment block describing the different blocks available from ixc_core/base.html.
- Changed the low-level elements to use classes rather than ids, and changed the selectors to be both more verbose and to use camel-case.
