### PR TITLE
Remove frontend compiler app from INSTALLED_APPS

### DIFF
--- a/djangosite/settings/base.py
+++ b/djangosite/settings/base.py
@@ -168,7 +168,6 @@ INSTALLED_APPS = (
     'reversion',
 
     # IC.
-    'django_frontend_compiler',
 
     # Project.
     '{{ project_name }}',


### PR DESCRIPTION
We no longer have `django_frontend_compiler` in setup.py or requirements[-dev].txt, and it throws an error on startup if it's missing.